### PR TITLE
common/bitmovin_json_decoder: Don't compare numbers with `is`

### DIFF
--- a/bitmovin_api_sdk/common/bitmovin_json_decoder.py
+++ b/bitmovin_api_sdk/common/bitmovin_json_decoder.py
@@ -75,7 +75,7 @@ class BitmovinJsonDecoder(object):
                     if re.match('list', type_, re.I):
                         matches = re.search(r'\[(.*)\]', type_)
 
-                        if matches is not None and len(matches.groups()) is 1:
+                        if matches is not None and len(matches.groups()) == 1:
                             if getattr(BitmovinJsonDecoder.model_module, matches.group(1)):
                                 model_class = getattr(BitmovinJsonDecoder.model_module,
                                                       matches.group(1))


### PR DESCRIPTION
In Python, the `is` operator is used to check for identity while
the `==` operator is used to check for equality.

When comparing the return value of `len`, the value should be checked
for equality, not identity.

Python warns about this with the following message:

    SyntaxWarning: "is" with a literal. Did you mean "=="?