### PR TITLE
Fix rate type error

### DIFF
--- a/bitmovin_api_sdk/models/stream_infos_details.py
+++ b/bitmovin_api_sdk/models/stream_infos_details.py
@@ -96,7 +96,7 @@ class StreamInfosDetails(object):
             'media_type': 'MediaType',
             'width': 'int',
             'height': 'int',
-            'rate': 'int',
+            'rate': 'float',
             'codec': 'LiveEncodingCodec',
             'samples_read_per_second_min': 'float',
             'samples_read_per_second_max': 'float',
@@ -256,30 +256,30 @@ class StreamInfosDetails(object):
 
     @property
     def rate(self):
-        # type: () -> int
+        # type: () -> float
         """Gets the rate of this StreamInfosDetails.
 
         The rate (sample rate / fps) of the stream (required)
 
         :return: The rate of this StreamInfosDetails.
-        :rtype: int
+        :rtype: float
         """
         return self._rate
 
     @rate.setter
     def rate(self, rate):
-        # type: (int) -> None
+        # type: (float) -> None
         """Sets the rate of this StreamInfosDetails.
 
         The rate (sample rate / fps) of the stream (required)
 
         :param rate: The rate of this StreamInfosDetails.
-        :type: int
+        :type: float
         """
 
         if rate is not None:
-            if not isinstance(rate, int):
-                raise TypeError("Invalid type for `rate`, type has to be `int`")
+            if not isinstance(rate, float):
+                raise TypeError("Invalid type for `rate`, type has to be `float`")
 
         self._rate = rate
 


### PR DESCRIPTION
Encountered "Invalid type for `rate`, type has to be `int`" while trying to do the following:

`bitmovin_api = BitmovinApi(api_key=api_key, logger=BitmovinApiLogger())`
`bitmovin_api.encoding.statistics.encodings.live_statistics.streams.list(encoding_id)`


Rate is returned as float by the API (Long type on other languages)